### PR TITLE
fix: omit non-essential types

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -84,7 +84,7 @@ export interface CarouselProps {
 
   /* Status */
   showStatus?: boolean
-  status?: StatusProps
+  status?: Omit<StatusProps, "length" | "curIndex">
 
   /* Arrows */
   showArrows?: boolean
@@ -92,7 +92,7 @@ export interface CarouselProps {
 
   /* Indicators */
   showIndicators?: boolean
-  indicators?: IndicatorsProps
+  indicators?: Omit<IndicatorsProps, "length" | "curIndex">
 }
 
 type DefaultContext = {


### PR DESCRIPTION
- curIndex and length in statusProps are automatically handled inside the Carousel component.
- curIndex and length in indicatorsProps are automatically handled inside the Carousel component.